### PR TITLE
Update patterns

### DIFF
--- a/crawlers.go
+++ b/crawlers.go
@@ -86,6 +86,7 @@ var crawlers = []string{
 	`alyze\.info`,
 	`amagit`,
 	`^Amazon Simple Notification Service Agent$`,
+	`^Amazon-Route53-Health-Check-Service`,
 	`Anarchie`,
 	`AndroidDownloadManager`,
 	`Anemone`,

--- a/testdata/crawlers.txt
+++ b/testdata/crawlers.txt
@@ -3627,3 +3627,4 @@ nettle (+https://www.nettle.sk)
 NihilScio - Educational search engine - +https://www.nihilscio.it/NihilScio.htm
 Miro-HttpClient/1.0
 mio_httpc 0.9.4
+Amazon-Route53-Health-Check-Service (ref c96ad03c-acdf-48c6-8ec7-45806bf08123; report http://amzn.to/1vsZADi)


### PR DESCRIPTION
Add new crawlers:
- Amazon Route53 Health Check

Corresponds to upstream v1.2.108