### PR TITLE
build: bump to Go 1.27

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ workflows:
 jobs:
   build:
     docker:
-      - image: cimg/go:1.26
+      - image: cimg/go:1.27
 
     steps:
       - checkout

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/x-way/crawlerdetect
 
-go 1.24.6
+go 1.27.0


### PR DESCRIPTION
Bump the go.mod language version and CircleCI build image to Go 1.27.