### PR TITLE
security: explicit workflow permissions + persist-credentials:false on checkout

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,6 +41,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v7
+      with:
+        persist-credentials: false
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL


### PR DESCRIPTION
Implements tasks #13 and #14 from the x-way GitHub Actions security review.

- `codeql.yml`: added `persist-credentials: false` to the checkout step. (This file already had an explicit `permissions:` block, so task #13 was a no-op here.)