### PR TITLE
Add govulncheck and gosec to CI pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,16 @@ jobs:
                     go install honnef.co/go/tools/cmd/staticcheck@latest
                     staticcheck -checks all ./...
       - run:
+          name: govulncheck
+          command: |
+                    go install golang.org/x/vuln/cmd/govulncheck@latest
+                    govulncheck ./...
+      - run:
+          name: gosec
+          command: |
+                    go install github.com/securego/gosec/v2/cmd/gosec@latest
+                    gosec ./...
+      - run:
           name: Check gofumpt formatting
           command: |
                     go install mvdan.cc/gofumpt@latest


### PR DESCRIPTION
crawlerdetect has no Makefile; its build system is CircleCI. Adds govulncheck and gosec as CircleCI steps, matching the existing staticcheck step's style.