### PR TITLE
Update CircleCI config to version 2.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,5 @@
-version: 2
+version: 2.1
 workflows:
-  version: 2
   build:
     jobs:
       - build


### PR DESCRIPTION
CircleCI is [ending support for config version 2.0](https://discuss.circleci.com/t/breaking-changes-config-compilation-updates-july-17-2026/54719) and pipelines using it will fail to compile. This bumps `.circleci/config.yml` from `version: 2` to `version: 2.1` and drops the now-vestigial `workflows.version` key. No other config in this repo triggers the other breaking changes (undeclared parameters, removed regex features, job/branch-filter syntax).